### PR TITLE
Bus changes

### DIFF
--- a/lib/pub_sub/active_record/model.rb
+++ b/lib/pub_sub/active_record/model.rb
@@ -11,6 +11,10 @@ module PubSub
         base.include PubSub::Publisher
         base.prepend PubSub::ClassForwarding
         base.include PubSub::ActiveRecord::Callbacks
+
+        def base.on_event(...)
+          broadcast(...)
+        end
       end
     end
   end

--- a/lib/pub_sub/bus.rb
+++ b/lib/pub_sub/bus.rb
@@ -4,25 +4,13 @@ require_relative "publisher.rb"
 module PubSub
   module Bus
     def self.included(base)
-      base.class_eval do
-        include PubSub::Subscriber
-        include PubSub::Publisher
-
-        def on_event(...)
-          broadcast(...)
-        end
-      end
+      base.include PubSub::Subscriber
+      base.include PubSub::Publisher
     end
 
     def self.extended(base)
-      base.class_eval do
-        extend PubSub::Subscriber
-        extend PubSub::Publisher
-
-        def self.on_event(...)
-          broadcast(...)
-        end
-      end
+      base.extend PubSub::Subscriber
+      base.extend PubSub::Publisher
     end
   end
 end

--- a/spec/bus_spec.rb
+++ b/spec/bus_spec.rb
@@ -26,15 +26,27 @@ RSpec.describe PubSub::Bus do
 
     class ClassForwardingBus
       extend PubSub::Bus
+
+      def self.on_event(...)
+        broadcast(...)
+      end
     end
 
     class InstanceForwardingBus
       include PubSub::Bus
+
+      def on_event(...)
+        broadcast(...)
+      end
     end
 
     class SingletonForwardingBus
       include Singleton
       include PubSub::Bus
+
+      def on_event(...)
+        broadcast(...)
+      end
     end
 
     class DoublingBus


### PR DESCRIPTION
Previously `PubSub::Bus` would provide a default forwarding implementation, but that would overwrite the event matching API which is pretty important for more complex buses. So, instead, I'm now going to have `PubSub::Bus` just be a wrapper `PubSub::Subscriber` and `PubSub::Publisher`. Simple. Forwarding buses will now have to write their own forwarding event handler (literally 3 lines of code), but all the convenience event matching APIs will work. Seems like a good trade off to me. 