### PR TITLE
Fix class forwarding

### DIFF
--- a/lib/pub_sub/active_record/class_forwarding.rb
+++ b/lib/pub_sub/active_record/class_forwarding.rb
@@ -1,0 +1,15 @@
+module PubSub
+  module ActiveRecord
+    module ClassForwarding
+      def self.included(base)
+        base.class_eval do
+          after_initialize :subscribe_class
+
+          def subscribe_class
+            add_subscriber(self.class)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pub_sub/active_record/model.rb
+++ b/lib/pub_sub/active_record/model.rb
@@ -1,6 +1,6 @@
 require_relative "../bus.rb"
 require_relative "../publisher.rb"
-require_relative "../class_forwarding.rb"
+require_relative "class_forwarding.rb"
 require_relative "callbacks.rb"
 
 module PubSub
@@ -9,7 +9,7 @@ module PubSub
       def self.extended(base)
         base.extend PubSub::Bus
         base.include PubSub::Publisher
-        base.prepend PubSub::ClassForwarding
+        base.include PubSub::ActiveRecord::ClassForwarding
         base.include PubSub::ActiveRecord::Callbacks
 
         def base.on_event(...)

--- a/lib/pub_sub/class_forwarding.rb
+++ b/lib/pub_sub/class_forwarding.rb
@@ -1,8 +1,0 @@
-module PubSub
-  module ClassForwarding
-    def initialize(...)
-      add_subscriber(self.class)
-      super(...)
-    end
-  end
-end


### PR DESCRIPTION
AR doesn't actually call a class's initialize function when making a new instance sometimes. So, the foolproof way to handle this is an after_initialize callback which is what this does.