### PR TITLE
Async subscriber module

### DIFF
--- a/lib/pub_sub/subscriber_worker.rb
+++ b/lib/pub_sub/subscriber_worker.rb
@@ -2,25 +2,30 @@ require "sidekiq"
 require "yaml"
 
 module PubSub
-  class SubscriberWorker
-    include Sidekiq::Worker
-    extend PubSub::Subscriber
-
-    sidekiq_options retry: false
-
-    class << self
-      alias :on_event_sync :on_event
-
-      def on_event(event)
-        perform_async({
-          "event_class_name" => event.class.name,
-          "payload" => event.payload
-        })
-      end
+  module AsyncSubscriber
+    def self.included(base)
+      raise "AsyncSubscriber doesn't support being included. It must be extended."
     end
 
-    def perform(args)
-      self.class.on_event_sync(Object.const_get(args["event_class_name"]).new(args["payload"]))
+    def self.extended(base)
+      base.extend PubSub::Subscriber
+
+      base.class_eval do
+        class << self
+          alias :on_event_sync :on_event
+    
+          def on_event(event)
+            perform_async({
+              "event_class_name" => event.class.name,
+              "payload" => event.payload
+            })
+          end
+        end
+
+        def perform(args)
+          self.class.on_event_sync(Object.const_get(args["event_class_name"]).new(args["payload"]))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The way I was doing it before required the consumer to run an extra Sidekiq process for the new worker. This way, they can supply the worker and just `extend AsyncSubscriber` to get the same functionality.